### PR TITLE
Updating ArtifactOfUnity's Warning Messages

### DIFF
--- a/ArtifactsOfDoom/Artifacts/ArtifactOfUnity.cs
+++ b/ArtifactsOfDoom/Artifacts/ArtifactOfUnity.cs
@@ -120,7 +120,7 @@ namespace ArtifactGroup
 				orig.Invoke(self, damageReport);
 				if (ArtifactEnabled && damageReport.victim.body.isPlayerControlled && OptionsLink.AOU_DeathRecovery.Value == true) // check if a player died
 				{
-					MessageHandler.globalMessage(damageReport.victim.body.GetUserName() + " Has died! He will still receive items over time, though");
+					MessageHandler.globalMessage(damageReport.victim.body.GetUserName() + " has died! They will still receive items over time.");
 					if (!deathStorage.dead_players.Contains(damageReport.victim.body.GetUserName()))
 					{
 						deathStorage.dead_players.Add(damageReport.victim.body.GetUserName());


### PR DESCRIPTION
Updated the warning text for collecting items while dead with the ArtifactOfUnity. Hoping that this change would make the mod more comfortable for some users.